### PR TITLE
Fix .nojekyll not reaching GitHub Pages (CSS/layout broken)

### DIFF
--- a/.github/workflows/pages-gallery.yml
+++ b/.github/workflows/pages-gallery.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: pages-site
+          include-hidden-files: true  # needed for .nojekyll to disable Jekyll
 
       - name: Upload preview artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- `upload-pages-artifact@v5` excludes dotfiles by default (`include-hidden-files: false`)
- `.nojekyll` was therefore stripped from the artifact before upload
- Without `.nojekyll`, GitHub Pages runs Jekyll, which rewrites the HTML and drops the CSS grid layout and border-radius styles — causing tiles to render as a vertical list and code pills to appear square
- Fix: set `include-hidden-files: true` on the upload step

## Test plan
- [ ] CI Pages build succeeds
- [ ] Deployed site at https://aptg.github.io/2022_DCPT_LET/ shows plot tiles in a grid (not a vertical list)
- [ ] Code pills are round (border-radius applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)