### PR TITLE
Update S3 endpoint and bucket name for downloads

### DIFF
--- a/data/resources/phasespace/README.md
+++ b/data/resources/phasespace/README.md
@@ -8,10 +8,10 @@ The following table lists the binary files containing particles scored at a plan
 
 | Plan  | File                                                                                          |
 |-------|-----------------------------------------------------------------------------------------------|
-| Plan 1 | [plan01_sobp_field01.mcpl](https://s3.cloud.cyfronet.pl/2022_dcpt_let/mcpl/plan01_sobp_field01.mcpl) |  
-| Plan 2 | [plan02_mono_field01.mcpl](https://s3.cloud.cyfronet.pl/2022_dcpt_let/mcpl/plan02_mono_field01.mcpl) |
-| Plan 3 | [plan03_ramp_full_field01.mcpl](https://s3.cloud.cyfronet.pl/2022_dcpt_let/mcpl/plan03_ramp_full_field01.mcpl), [plan03_ramp_full_field02.mcpl](https://s3.cloud.cyfronet.pl/2022_dcpt_let/mcpl/plan03_ramp_full_field02.mcpl) |
-| Plan 4 | [plan04_ramp_middle_field01.mcpl](https://s3.cloud.cyfronet.pl/2022_dcpt_let/mcpl/plan04_ramp_middle_field01.mcpl), [plan04_ramp_middle_field02.mcpl](https://s3.cloud.cyfronet.pl/2022_dcpt_let/mcpl/plan04_ramp_middle_field02.mcpl) |
+| Plan 1 | [plan01_sobp_field01.mcpl](https://s3p.cloud.cyfronet.pl/2022dcptlet/mcpl/plan01_sobp_field01.mcpl) |  
+| Plan 2 | [plan02_mono_field01.mcpl](https://s3p.cloud.cyfronet.pl/2022dcptlet/mcpl/plan02_mono_field01.mcpl) |
+| Plan 3 | [plan03_ramp_full_field01.mcpl](https://s3p.cloud.cyfronet.pl/2022dcptlet/mcpl/plan03_ramp_full_field01.mcpl), [plan03_ramp_full_field02.mcpl](https://s3p.cloud.cyfronet.pl/2022dcptlet/mcpl/plan03_ramp_full_field02.mcpl) |
+| Plan 4 | [plan04_ramp_middle_field01.mcpl](https://s3p.cloud.cyfronet.pl/2022dcptlet/mcpl/plan04_ramp_middle_field01.mcpl), [plan04_ramp_middle_field02.mcpl](https://s3p.cloud.cyfronet.pl/2022dcptlet/mcpl/plan04_ramp_middle_field02.mcpl) |
 
 ## Particle Source
 

--- a/data/resources/plans/README.md
+++ b/data/resources/plans/README.md
@@ -21,7 +21,7 @@ is a ramp across entire SOBP, starting at 100 % dose proximal edge, 0 % dose dis
 - `ramped_2Gy_ver2_full.dcm`  Spot data
 - `RS1.2.752.243.1.1.20250522124652761.2000.43711.dcm`  Structure data
 
-The complete DICOM study, including CT data is available at [Plan03_Eclipse.zip](https://s3.cloud.cyfronet.pl/2022_dcpt_let/plans/Plan03_Eclipse.zip) and [Plan03_RayStation.zip](https://s3.cloud.cyfronet.pl/2022_dcpt_let/plans/Plan03_RayStation.zip)
+The complete DICOM study, including CT data is available at [Plan03_Eclipse.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan03_Eclipse.zip) and [Plan03_RayStation.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan03_RayStation.zip)
 
 ## Plan 04 `ramp_middle`
 is a special ramp:
@@ -35,7 +35,7 @@ is a special ramp:
 - `ramped_2Gy_ver1_middel.dcm`  Spot data
 - `RS1.2.752.243.1.1.20250522124652761.2000.43711.dcm`  Structure data
 
-The complete DICOM study, including CT data is available at - [Plan04_Eclipse.zip](https://s3.cloud.cyfronet.pl/2022_dcpt_let/plans/Plan04_Eclipse.zip) and [Plan04_RayStation.zip](https://s3.cloud.cyfronet.pl/2022_dcpt_let/plans/Plan04_RayStation.zip)
+The complete DICOM study, including CT data is available at - [Plan04_Eclipse.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan04_Eclipse.zip) and [Plan04_RayStation.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan04_RayStation.zip)
 
 ## Spotlists
 Corresponding easy-to-read spotlist files are added for each plan.

--- a/data/resources/plans/README.md
+++ b/data/resources/plans/README.md
@@ -35,7 +35,7 @@ is a special ramp:
 - `ramped_2Gy_ver1_middel.dcm`  Spot data
 - `RS1.2.752.243.1.1.20250522124652761.2000.43711.dcm`  Structure data
 
-The complete DICOM study, including CT data is available at - [Plan04_Eclipse.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan04_Eclipse.zip) and [Plan04_RayStation.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan04_RayStation.zip)
+The complete DICOM study, including CT data is available at [Plan04_Eclipse.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan04_Eclipse.zip) and [Plan04_RayStation.zip](https://s3p.cloud.cyfronet.pl/2022dcptlet/plans/Plan04_RayStation.zip)
 
 ## Spotlists
 Corresponding easy-to-read spotlist files are added for each plan.


### PR DESCRIPTION
## Summary
- The S3 bucket used for phase-space (`.mcpl`) and treatment plan (`.zip`) downloads moved from `s3.cloud.cyfronet.pl/2022_dcpt_let` to `s3p.cloud.cyfronet.pl/2022dcptlet`.
- Updated all links in `data/resources/phasespace/README.md` and `data/resources/plans/README.md`.
- Repo-wide search confirmed these were the only occurrences of the old bucket/endpoint; the `grzanka-mcpl-v1` bucket used in `data/phits/README.md` and `data/mcnp/README.md` is unrelated and already on the `s3p` endpoint.

## Test plan
- [x] Ranged GET (first 1KB) against all 10 updated URLs — all returned data successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)